### PR TITLE
Remove dependency on jquery

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,6 @@
 Meteor.startup(function() {
-  var dom = $('script[type="text/inject-data"]', document);
-  var injectedDataString = $.trim(dom.text());
+  var dom = document.querySelectorAll('script[type="text/inject-data"]');
+  var injectedDataString = dom && dom.length > 0 ? dom[0].innerHTML : "";
   InjectData._data = InjectData._decode(injectedDataString) || {};
 });
 

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ var path = Npm.require('path');
 
 Package.describe({
   "summary": "A way to inject data to the client with initial HTML",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "git": "https://github.com/abecks/meteor-inject-data",
   "name": "staringatlights:inject-data"
 });

--- a/package.js
+++ b/package.js
@@ -41,7 +41,6 @@ function configure(api) {
   api.versionsFrom('METEOR@0.9.3');
 
   api.use(['ejson', 'underscore'], ['server', 'client']);
-  api.use('jquery', 'client');
 
   api.addFiles([
     'lib/inject.html',


### PR DESCRIPTION
Simply removes the dependency on jquery and uses vanilla JS to get the injected data.

If this isn't desirable because you want to support older browsers (https://caniuse.com/#search=querySelectorAll) , I can instead make jquery a weak dependency and check if `$` is in scope; if so, select via jquery; otherwise, use the solution in this PR.