### PR TITLE
Remove underscore dependency from client

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,3 @@
-import { _ } from 'meteor/underscore'
 import { Meteor } from 'meteor/meteor'
 import { InjectData } from './namespace'
 import { WebApp, WebAppInternals } from 'meteor/webapp'
@@ -61,7 +60,7 @@ InjectData.pushData = function pushData(req, key, value) {
  */
 InjectData.getData = function getData(req, key) {
 	if (req.headers && req.headers._injectPayload) {
-		return _.clone(req.headers._injectPayload[key])
+		return Object.assign({}, req.headers._injectPayload[key]);
 	} else {
 		return null
 	}

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,9 +1,6 @@
-import { Meteor } from 'meteor/meteor'
-import { InjectData } from './namespace'
-import { WebApp, WebAppInternals } from 'meteor/webapp'
-import { Random } from 'meteor/random'
 
-const Env = new Meteor.EnvironmentVariable()
+import { InjectData } from './namespace'
+import { WebAppInternals } from 'meteor/webapp'
 
 // Supports legacy uses of inject data, SSR users should turn this to false
 InjectData.injectToHead = true

--- a/package.js
+++ b/package.js
@@ -9,7 +9,7 @@ Package.describe({
 Package.onUse(function(api) {
 	api.versionsFrom('METEOR@1.6.1')
 	api.use('webapp', 'server')
-	api.use(['ejson', 'underscore', 'ecmascript'], ['server', 'client'])
+	api.use(['ejson', 'ecmascript'], ['server', 'client'])
 	api.mainModule('lib/namespace.js', ['server', 'client'])
 	api.addFiles('lib/utils.js', ['server', 'client'])
 	api.addFiles('lib/server.js', 'server')

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 /* global Package */
 Package.describe({
 	summary: 'A way to inject data to the client with initial HTML',
-	version: '2.2.1',
+	version: '2.3.0',
 	git: 'https://github.com/abecks/meteor-inject-data',
 	name: 'staringatlights:inject-data',
 })


### PR DESCRIPTION
This had a dependency on `underscore` for both the client and server. `underscore` was only used on the server, so it didn't need to be a client dependency. I was going to make it a server only dependency, but it was only being used for `_.clone`, which can be replaced by `Object.assign`. Figured I'd might as well remove the dependency altogether.

Also noticed that some of the imports weren't being used, so just thought I'd clean that up in the process, too.